### PR TITLE
feature/#33CORS문제

### DIFF
--- a/src/main/java/com/awexomeray/TwoParkHanJungLim/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/awexomeray/TwoParkHanJungLim/config/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.awexomeray.TwoParkHanJungLim.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
@@ -11,6 +12,9 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Objects;
+
+import static org.springframework.http.HttpHeaders.*;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
@@ -18,6 +22,8 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        //preflight Request 발생 시 OPTIOINS 요청에 대해서는 토큰검사를 하면 안됨
+        if(isPreflightRequest((HttpServletRequest) request)) return;
         // 헤더에서 JWT 를 받아옵니다.
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
         // 유효한 토큰인지 확인합니다.
@@ -28,5 +34,27 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         chain.doFilter(request, response);
+    }
+
+    //options request인지 판단 (preflight request인지)
+    private boolean isPreflightRequest(HttpServletRequest request) {
+        return isOptionsMethod(request) && hasOrigin(request)
+                && hasRequestMethods(request) && hasRequestHeaders(request);
+    }
+
+    public boolean isOptionsMethod(HttpServletRequest request) {
+        return request.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS.toString());
+    }
+
+    public boolean hasOrigin(HttpServletRequest request) {
+        return Objects.nonNull(request.getHeader(ORIGIN));
+    }
+
+    public boolean hasRequestMethods(HttpServletRequest request) {
+        return Objects.nonNull(request.getHeader(ACCESS_CONTROL_REQUEST_METHOD));
+    }
+
+    public boolean hasRequestHeaders(HttpServletRequest request) {
+        return Objects.nonNull(request.getHeader(ACCESS_CONTROL_REQUEST_HEADERS));
     }
 }

--- a/src/main/java/com/awexomeray/TwoParkHanJungLim/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/awexomeray/TwoParkHanJungLim/config/security/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.awexomeray.TwoParkHanJungLim.config.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -27,6 +28,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .csrf().disable() // csrf 보안 토큰 disable처리.
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 토큰 기반 인증이므로 세션 역시 사용하지 않습니다.
                 .and()
+                .cors(Customizer.withDefaults())
                 .authorizeRequests() // 요청에 대한 사용권한 체크
                 .antMatchers("/login/**").permitAll()
                 .antMatchers("/admin/**").hasRole("admin")


### PR DESCRIPTION
preflight request 요청시 OPTIONS 요청에 대해서 spring security의 filter가 토큰을 검사하게 되는데 

OPTIONS 요청에는 X-AUTH-TOKEN헤더를 찾지 못하여 인증이 되지 않는 것을 확인했습니다.

위 문제를 해결하기 위해 preflight 요청시 OPTIONS 요청에 대해서는 filter를 거치지 않도록 처리하여 해결했습니다